### PR TITLE
add request modal when clicking on the 'details' button

### DIFF
--- a/client/src/components/UI/AcceptRequestModal.jsx
+++ b/client/src/components/UI/AcceptRequestModal.jsx
@@ -4,8 +4,7 @@ const Button = ({ className, onClick, children }) => (
   <button
     className={`font-bold uppercase text-sm px-6 py-2 rounded shadow hover:shadow-lg outline-none focus:outline-none ease-linear transition-all duration-150 ${className}`}
     type="button"
-    onClick={onClick}
-  >
+    onClick={onClick}>
     {children}
   </button>
 );
@@ -25,8 +24,7 @@ function AcceptRequestModal({ request, onClose }) {
             <h3 className="text-xl font-semibold">Request Details</h3>
             <button
               className="bg-transparent border-0 text-black float-right"
-              onClick={onClose}
-            >
+              onClick={onClose}>
               <span className="text-black h-6 w-6 block bg-gray-400 rounded-full">
                 X
               </span>
@@ -38,8 +36,8 @@ function AcceptRequestModal({ request, onClose }) {
               Title: {request?.title} <br />
               Location: {request?.location?.city}, {request?.location?.country}
               <br />
-              Latitude: {request?.location?.lat || "N/A"} <br />
-              Longitude: {request?.location?.lng || "N/A"} <br />
+              Latitude: {request?.location?.coordinates} <br />
+              Longitude: {request?.location?.coordinates} <br />
               Email: (Upon Accept) <br />
               Contact No.: (Upon Accept)
             </p>
@@ -58,8 +56,7 @@ function AcceptRequestModal({ request, onClose }) {
 
                 <Button
                   className="bg-white text-gray-900 border border-[#F4743B]"
-                  onClick={onClose}
-                >
+                  onClick={onClose}>
                   Cancel
                 </Button>
               </div>

--- a/client/src/components/UI/AcceptRequestModal.jsx
+++ b/client/src/components/UI/AcceptRequestModal.jsx
@@ -1,0 +1,79 @@
+import PropTypes from "prop-types";
+
+const Button = ({ className, onClick, children }) => (
+  <button
+    className={`font-bold uppercase text-sm px-6 py-2 rounded shadow hover:shadow-lg outline-none focus:outline-none ease-linear transition-all duration-150 ${className}`}
+    type="button"
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
+
+Button.propTypes = {
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+  children: PropTypes.node.isRequired,
+};
+
+function AcceptRequestModal({ request, onClose }) {
+  return (
+    <div className="flex justify-center items-center overflow-x-hidden overflow-y-auto fixed inset-0 z-50 bg-gray-500 bg-opacity-75 transition-opacity">
+      <div className="relative p-8 w-full max-w-lg max-h-full">
+        <div className="border-0 rounded-lg shadow-lg relative flex flex-col w-full bg-white outline-none focus:outline-none">
+          <div className="flex items-start justify-between p-5 border-b border-solid border-gray-300 rounded-t">
+            <h3 className="text-xl font-semibold">Request Details</h3>
+            <button
+              className="bg-transparent border-0 text-black float-right"
+              onClick={onClose}
+            >
+              <span className="text-black h-6 w-6 block bg-gray-400 rounded-full">
+                X
+              </span>
+            </button>
+          </div>
+
+          <div className="p-8 flex flex-col items-start">
+            <p className="text-gray-700 text-lg mb-6 text-left">
+              Title: {request?.title} <br />
+              Location: {request?.location?.city}, {request?.location?.country}
+              <br />
+              Latitude: {request?.location?.lat || "N/A"} <br />
+              Longitude: {request?.location?.lng || "N/A"} <br />
+              Email: (Upon Accept) <br />
+              Contact No.: (Upon Accept)
+            </p>
+
+            <div className="flex justify-between w-full">
+              <div>
+                <Button className="bg-[#F4743B] text-white" onClick={onClose}>
+                  Accept
+                </Button>
+              </div>
+
+              <div className="flex space-x-4">
+                <Button className="bg-white text-gray-900 border border-[#F4743B]">
+                  <i className="fas fa-edit mr-1"></i> Edit
+                </Button>
+
+                <Button
+                  className="bg-white text-gray-900 border border-[#F4743B]"
+                  onClick={onClose}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+AcceptRequestModal.propTypes = {
+  request: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default AcceptRequestModal;

--- a/client/src/components/UserProfile/RequestTable.jsx
+++ b/client/src/components/UserProfile/RequestTable.jsx
@@ -1,94 +1,32 @@
-import DataTable from 'react-data-table-component';
-import { Button } from '../UI/Button';
+import DataTable from "react-data-table-component";
+import { Button } from "../UI/Button";
 // import tempRequestdata  from './tempRequestdata';
-import PropTypes from 'prop-types';
-import { useAuth0 } from '@auth0/auth0-react';
-import { useState, useEffect } from 'react';
-import axios from 'axios';
+import PropTypes from "prop-types";
+import { useAuth0 } from "@auth0/auth0-react";
+import { useState, useEffect } from "react";
+import axios from "axios";
+import AcceptRequestModal from "../UI/AcceptRequestModal";
 
 const tableCustomStyles = {
   headRow: {
     style: {
-      backgroundColor: '#F8F8F8',
+      backgroundColor: "#F8F8F8",
     },
   },
 };
-const columns = [
-  {
-    id: 'title',
-    name: 'Title',
-    selector: (row) => row.title,
-  },
-  {
-    id: 'status',
-    name: 'Status',
-    selector: (row) => (row.isActive ? 'Active' : 'Inactive'),
-    sortable: true,
-  },
-  {
-    id: 'city',
-    name: 'City',
-    selector: (row) => row.location.city,
-    sortable: true,
-  },
-  {
-    id: 'country',
-    name: 'Country',
-    selector: (row) => row.location.country,
-    sortable: true,
-  },
-  {
-    id: 'date',
-    name: 'Date',
-    selector: (row) => row.createdAt,
-    sortable: true,
-  },
-  {
-    id: 'details',
-    name: 'Select',
-    button: true,
-    cell: () => (
-      <Button
-        className='font-normal border border-[#F4743B] hover:bg-[#F4743B] rounded-lg p-1 dark:text-white'
-        type='button'
-        text='Details'
-      ></Button>
-    ),
-  },
-  {
-    id: 'cancel',
-    button: true,
-    cell: () => (
-      <Button
-        className='font-normal border border-[#F4743B] hover:bg-[#F4743B] rounded-lg p-1 dark:text-white'
-        type='button'
-        text='Cancel'
-      ></Button>
-    ),
-  },
-  {
-    id: 'completed',
-    button: true,
-    cell: () => (
-      <Button
-        className='font-normal border border-green-500 hover:bg-green-300 rounded-lg p-1 dark:text-white'
-        type='button'
-        text='Completed'
-      ></Button>
-    ),
-  },
-];
 
 export const RequestComponent = ({ fixedHeader, fixedHeaderScrollHeight }) => {
   const { getAccessTokenSilently } = useAuth0();
   const [requestData, setRequestData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [selectedRequest, setSelectedRequest] = useState(null);
 
   useEffect(() => {
     const fetchUserData = async () => {
       try {
         const accessToken = await getAccessTokenSilently();
-        const response = await axios.get('http://localhost:3003/api/requests', {
+        const response = await axios.get("http://localhost:3003/api/requests", {
           headers: {
             Authorization: `Bearer ${accessToken}`,
           },
@@ -104,16 +42,106 @@ export const RequestComponent = ({ fixedHeader, fixedHeaderScrollHeight }) => {
     fetchUserData();
   }, [getAccessTokenSilently]);
 
+  const handleDetailsClick = (row) => {
+    setSelectedRequest(row);
+    setShowModal(true);
+  };
+
+  const handleModalClose = () => {
+    setShowModal(false);
+    setSelectedRequest(null);
+  };
+
+  const columns = [
+    {
+      id: "title",
+      name: "Title",
+      selector: (row) => row.title,
+    },
+    {
+      id: "status",
+      name: "Status",
+      selector: (row) => (row.isActive ? "Active" : "Inactive"),
+      sortable: true,
+    },
+    {
+      id: "city",
+      name: "City",
+      selector: (row) => row.location.city,
+      sortable: true,
+    },
+    {
+      id: "country",
+      name: "Country",
+      selector: (row) => row.location.country,
+      sortable: true,
+    },
+    {
+      id: "date",
+      name: "Date",
+      selector: (row) => row.createdAt,
+      sortable: true,
+    },
+    {
+      id: "details",
+      name: "Select",
+      button: true,
+      cell: (row) => (
+        <Button
+          className="font-normal border border-[#F4743B] hover:bg-[#F4743B] hover:text-white rounded-lg p-1 dark:text-white"
+          type="button"
+          text="Details"
+          onClick={() => handleDetailsClick(row)}
+        />
+      ),
+    },
+    {
+      id: "edit",
+      button: true,
+      cell: (row) =>
+        selectedRequest?.id === row.id ? (
+          <i className="fas fa-edit mr-1 text-lg"></i>
+        ) : (
+          <Button
+            className="font-normal border border-[#F4743B] hover:bg-[#F4743B] hover:text-white rounded-lg p-1 dark:text-white"
+            type="button"
+            text="Cancel"
+          />
+        ),
+    },
+    {
+      id: "completed",
+      button: true,
+      cell: (row) =>
+        selectedRequest?.id !== row.id && (
+          <Button
+            className="font-normal border border-green-500 hover:bg-green-300 rounded-lg p-1 dark:text-white"
+            type="button"
+            text="Completed"
+          />
+        ),
+    },
+  ];
+
   return (
-    <DataTable
-      columns={columns}
-      data={requestData}
-      fixedHeader={fixedHeader}
-      fixedHeaderScrollHeight={fixedHeaderScrollHeight}
-      customStyles={tableCustomStyles}
-      pagination
-      progressPending={loading}
-    />
+    <>
+      <DataTable
+        columns={columns}
+        data={requestData}
+        fixedHeader={fixedHeader}
+        fixedHeaderScrollHeight={fixedHeaderScrollHeight}
+        customStyles={tableCustomStyles}
+        pagination
+        progressPending={loading}
+      />
+
+      {showModal && (
+        <AcceptRequestModal
+          request={selectedRequest}
+          onClose={handleModalClose}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
# UPDATES
- Created a request modal (`AcceptRequestModal.jsx`) for the 'Details' button, which opens a Request Details modal upon click.
- Integrated the modal within the `RequestTable.jsx` component.
- Modified the `RequestTable.jsx` component to toggle the edit button when the 'Details' button is clicked.
- Added a white text color effect to the 'Details' and 'Cancel' buttons on hover for a cleaner look.
- As per Jira issue 73 ([link](https://kseniiariabova.atlassian.net/jira/software/projects/BEE/boards/6?selectedIssue=BEE-73)), the modal is designed to display details and information for the selected city.

# QA
- It may be beneficial to refactor the columns object in the `RequestTable.jsx` component, moving it to a different location for improved readability later. 
- Focused on functionality; the modal could be further enhanced for responsiveness in the future.

# Attachments
- Please see the attached files and feel free to provide feedback.
![requestDetails](https://github.com/user-attachments/assets/d050b115-141f-4e54-8e8b-bd54e2015c2b)


